### PR TITLE
added content_list (NodeListField) attribute to InlineRelsInt()

### DIFF
--- a/bdrxml/foxml.py
+++ b/bdrxml/foxml.py
@@ -122,7 +122,7 @@ class InlineRelsInt(DatastreamVersion):
     ROOT_NAMESPACES = {'foxml': FOXNS,
                        'rdf': RDFNS}
     content = NodeField('foxml:xmlContent/rdf:RDF', Content)
-    content_list = NodeListField('foxml:xmlContent', Content)
+    content_list = NodeListField('foxml:xmlContent/rdf:RDF', Content)
     
 class Datastream(xmlmap.XmlObject):
     """


### PR DESCRIPTION
Allows syntax like:

```
>>> iri = InlineRelsInt()
>>> ri = RelsInt()
>>> ri.about = u'aaa'
>>> ri.download_filename = u'bbb'
>>> version.content_list.append( ri )
>>> ri2 = RelsInt()
>>> ri2.about = u'ccc'
>>> ri2.download_filename = u'ddd'
>>> iri.content_list.append( ri2 )
```

...resulting in multiple rdf:RDF entries like:

```
<foxml:xmlContent>
  <rdf:RDF ...
    <rdf:Description ...
      <fedora-model:downloadFilename> ...
    </rdf:Description>
  </rdf:RDF>
  <rdf:RDF ...
    <rdf:Description ...
      <fedora-model:downloadFilename> ...
    </rdf:Description>
  </rdf:RDF>
</foxml:xmlContent>
```
