### PR TITLE
Speed up travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 before_install:
  - sudo apt-get install -qq libxml2-dev libxslt-dev
+env:
+  - CFLAGS="-O0"
 python:
   - 2.6
   - 2.7


### PR DESCRIPTION
Change travis-ci configuration to use the system package for libxml and
libxslt.  And set the optimization to 0.  This cut the time to run each
travis test by more than half.
